### PR TITLE
Added new atomic test: Update T1105.yaml

### DIFF
--- a/atomics/T1105/T1105.yaml
+++ b/atomics/T1105/T1105.yaml
@@ -872,3 +872,24 @@ atomic_tests:
     cleanup_command: rmdir /s /q "C:\Temp\Sample" >nul 2>nul
     name: command_prompt
     elevation_required: true
+- name: File download via nscurl
+  description: |
+     Use nscurl to download and write a file/payload from the internet.
+     -k = Disable certificate checking
+     -o = Output destination
+  supported_platforms:
+  - macos
+  input_arguments:
+    remote_file:
+      description: URL of remote file to download
+      type: url
+      default: https://raw.githubusercontent.com/redcanaryco/atomic-red-team/master/LICENSE.txt
+    destination_path:
+      description: Local path to place remote file
+      type: path
+      default: license.txt
+  executor:
+    command: nscurl -k #{remote_file} -o #{destination_path}
+    cleanup_command: rm #{destination_path}
+    name: sh
+    elevation_required: false


### PR DESCRIPTION
**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->
Added a new atomic test for T1105 (Ingress Tool Transfer) to download a remote file or payload using in-built binary `nscurl` on macOS.

**Testing:**
<!-- Note any testing done, local or automated here. -->
<img width="1009" alt="testing" src="https://github.com/pratinavchandra/atomic-red-team/assets/25433956/1893d407-f0cd-4b95-8aa7-51cf12c8e4b3">


**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->